### PR TITLE
[BUGFIX] generate url to root page 

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -62,10 +62,8 @@ setDocumentClass : function(className) {
     10 = TEXT
     10 {
         typolink {
-            parameter.data = TSFE:id
+            parameter.data = leveluid:0
             additionalParams = &type=314638125&tx_pxacookiebar_pxacookiebar[action]=closeWarning
-            addQueryString = 1
-            addQueryString.method = GET
             useCacheHash = 1
             forceAbsoluteUrl = 1
             returnLast = url


### PR DESCRIPTION
generate url to root page  without get parameters to avoid 404 page on single view, because of chash error