### PR TITLE
Migrate some of the deprecated stuff 

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -23,6 +23,7 @@ plugin.tx_pxacookiebar {
         activeConsent = {$plugin.tx_pxacookiebar.settings.activeConsent}
         oneTimeVisible = {$plugin.tx_pxacookiebar.settings.oneTimeVisible}
         detailPageUid = {$plugin.tx_pxacookiebar.settings.detailPageUid}
+        position = {$plugin.tx_pxacookiebar.settings.position}
 
         closeCookiePageType = 314638125
     }
@@ -98,10 +99,3 @@ cookieWarningCloseCookie.5 {
         }
     }
 }
-
-# Position of bar
-[globalVar = LIT:bottom={$plugin.tx_pxacookiebar.settings.position}]
-    plugin.tx_pxacookiebar.settings.wrapperClasses = bottom-message-wrap
-[else]
-    plugin.tx_pxacookiebar.settings.wrapperClasses = top-message-wrap
-[global]

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -52,7 +52,7 @@ page.11905 = USER
 page.11905 {
     userFunc = TYPO3\CMS\Extbase\Core\Bootstrap->run
     extensionName = PxaCookieBar
-    pluginName = Pi1
+    pluginName = warningMessage
     vendorName = Pixelant
 
     settings =< plugin.tx_pxacookiebar.settings
@@ -75,13 +75,8 @@ page.headerData.84 {
     20 = COA
     20 {
         10 < page.11905
-        10 {
-            switchableControllerActions {
-                CookieWarning {
-                    1 = getJsCookieWarningSettings
-                }
-            }
-        }
+        10.pluginName = jsCookieWarningSettings
+
         wrap = <script>PxaCookieBarHelper.setSettings(|);PxaCookieBarHelper.init();</script>
     }
 }
@@ -92,10 +87,4 @@ cookieWarningCloseCookie.config.disableAllHeaderCode = 1
 cookieWarningCloseCookie.config.debug = 0
 
 cookieWarningCloseCookie.5 < page.11905
-cookieWarningCloseCookie.5 {
-    switchableControllerActions {
-        CookieWarning {
-            1 = closeCookieBar
-        }
-    }
-}
+cookieWarningCloseCookie.5.pluginName = closeCookieBar

--- a/Resources/Private/Templates/CookieWarning/WarningMessage.html
+++ b/Resources/Private/Templates/CookieWarning/WarningMessage.html
@@ -21,7 +21,7 @@
 
     <f:section name="cookieWarningTemplate">
         <div id="pxa-cookie-bar"
-             class="{settings.wrapperClasses}{f:if(then: ' active-consent', else: ' passive-consent', condition: activeConsent)}">
+             class="{settings.position}-message-wrap {f:if(then: 'active-consent', else: 'passive-consent', condition: activeConsent)}">
             <div class="cookie-warning">
                 <div class="cookie-container">
                     <div class="cookie-row">

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -5,9 +5,25 @@ call_user_func(
     function () {
         \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
             'Pixelant.PxaCookieBar',
-            'Pi1',
+            'warningMessage',
             [
-                'CookieWarning' => 'warningMessage, getJsCookieWarningSettings, closeCookieBar'
+                'CookieWarning' => 'warningMessage',
+            ]
+        );
+
+        \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
+            'Pixelant.PxaCookieBar',
+            'jsCookieWarningSettings',
+            [
+                'CookieWarning' => 'getJsCookieWarningSettings',
+            ]
+        );
+
+        \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
+            'Pixelant.PxaCookieBar',
+            'closeCookieBar',
+            [
+                'CookieWarning' => 'closeCookieBar'
             ]
         );
 


### PR DESCRIPTION
## Support of TYPO3 10

Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Description

1. Migrate deprecated TS condition
2. Remove usage of `switchableControllerActions`
